### PR TITLE
Changed to use Slim's own header management methods

### DIFF
--- a/SlimNoCache.php
+++ b/SlimNoCache.php
@@ -5,10 +5,11 @@ namespace SlimNoCache;
 class SlimNoCache extends \Slim\Middleware {
 
     public function call() {
+    	$rsp = $this->app->response();
+    	
     	// Based on http://stackoverflow.com/a/13640164
-        header("Cache-Control: no-store, no-cache, must-revalidate, max-age=0");
-        header("Cache-Control: post-check=0, pre-check=0", false);
-        header("Pragma: no-cache");
+        $rsp->headers->set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0, post-check=0, pre-check=0");
+        $rsp->headers->set("Pragma", "no-cache");
 
         $this->next->call();
     }


### PR DESCRIPTION
According to a support ticket response here
http://help.slimframework.com/discussions/problems/16-unable-to-understa
nd-how-app-response-header-work, you should never use the native PHP
header() method as this will flush headers before the Slim application
can finish what it needs to do. Therefore I have changed SlimNoCache to
use the recommended method for setting response headers.
